### PR TITLE
fix(footer): Remove broken Badginator badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,6 @@ A nice badge to give a link to [saythanks.io/to/kennethreitz](https://saythanks.
 © [Lilian Besson](https://GitHub.com/Naereen), 2016-18.
 
 [![Awesome Badges](https://img.shields.io/badge/badges-awesome-green.svg)](https://github.com/Naereen/badges)
-[![BADGINATOR](https://badginator.herokuapp.com/Naereen/badges.svg)](https://github.com/defunctzombie/badginator)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/Naereen/badges/graphs/commit-activity)
 [![Ask Me Anything !](https://img.shields.io/badge/Ask%20me-anything-1abc9c.svg)](https://GitHub.com/Naereen/ama)
 [![Analytics](https://ga-beacon.appspot.com/UA-38514290-17/github.com/Naereen/badges/README.md?pixel)](https://GitHub.com/Naereen/badges/)

--- a/README.rst
+++ b/README.rst
@@ -1258,7 +1258,7 @@ License ? |GitHub license badges|
 `MIT Licensed <https://lbesson.mit-license.org/>`__ (file `LICENSE <LICENSE>`__).
 © `Lilian Besson <https://GitHub.com/Naereen>`__, 2016-18.
 
-|Awesome Badges| |BADGINATOR| |Maintenance| |Ask Me Anything !| |Analytics badges| |Open Source Love svg3|
+|Awesome Badges| |Maintenance| |Ask Me Anything !| |Analytics badges| |Open Source Love svg3|
 
 |ForTheBadge built-with-swag|
 
@@ -1446,8 +1446,6 @@ License ? |GitHub license badges|
     :target: https://github.com/Naereen/badges/
 .. |Awesome Badges| image:: https://img.shields.io/badge/badges-awesome-green.svg
     :target: https://github.com/Naereen/badges
-.. |BADGINATOR| image:: https://badginator.herokuapp.com/Naereen/badges.svg
-    :target: https://github.com/defunctzombie/badginator
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.1007/978-3-319-76207-4_15.svg
     :target: https://doi.org/10.1007/978-3-319-76207-4_15
 .. |say thanks| image:: https://img.shields.io/badge/say-thanks-ff69b4.svg


### PR DESCRIPTION
Badginator appears to have been abandoned and is not longer functioning. Pity.

See https://github.com/defunctzombie/badginator/issues/12